### PR TITLE
Add Enova Power utility documentation

### DIFF
--- a/docs/utilities/enova-hydro.md
+++ b/docs/utilities/enova-hydro.md
@@ -1,0 +1,14 @@
+# Enova Power (Ontario, Canada)
+
+## Provider
+
+Green Button services for Enova Power are provided by Savage Data.
+
+## Information on File
+
+Registration created by Kate Kennedy (@kennek6) using her own contact information.
+See https://github.com/rocketraman/open-green-button/issues/36.
+
+## mTLS Status
+
+Not yet verified.


### PR DESCRIPTION
Adds utility documentation page for Enova Power (Ontario, Canada), slug `enova_hydro`.

Green Button services provided by Savage Data. Registration submitted via https://enovaonboarding.savagedata.com/.

Related: #36