### PR TITLE
Add Enova Power sandbox entry

### DIFF
--- a/server/app/src/main/resources/utilities.conf
+++ b/server/app/src/main/resources/utilities.conf
@@ -150,6 +150,26 @@ utilities = [
   }
 
   # ---------------------------------------------------------------------------------------------
+  # Enova Power
+  #
+  # Operated by Savage Data — certification sandbox.
+  #
+  # Registered via https://enovaonboarding.savagedata.com/ by Kate Kennedy (@kennek6).
+  # See https://github.com/rocketraman/open-green-button/issues/36.
+  #
+  # Registered redirect_uri: https://api.opengreenbutton.org/connect/enova_hydro/callback
+  # Registered thirdPartyNotifyUri: https://api.opengreenbutton.org/notify/enova_hydro
+  {
+    id = "enova_hydro"
+    displayName = "Enova Power, Ontario (SANDBOX FOR TESTING ONLY)"
+    authorizeUrl = "https://sandboxdc.savagedata.com:4243/connect/authorize"
+    tokenUrl = "https://sandboxdc.savagedata.com:4243/connect/token"
+    clientId = ${?OPENGB_UTILITY_ENOVA_HYDRO_CLIENTID}
+    clientSecret = ${?OPENGB_UTILITY_ENOVA_HYDRO_CLIENTSECRET}
+    defaultScope = "FB=1_3_4_5_6_8_12_15_16_17_27_28_36_37_40_51_54_55_56_57_58_59_60_61;SubscriptionFrequency=Daily"
+  }
+
+  # ---------------------------------------------------------------------------------------------
   # Enwin
   #
   # Operated by London Hydro


### PR DESCRIPTION
Adds an Enova Power sandbox entry to `utilities.conf` for testing.

- **Slug:** `enova_hydro`
- **Sandbox URL:** `sandboxdc.savagedata.com:4243` (shared Savage Data certification sandbox)
- **Scope:** Standard Savage Data ESPI scope matching other Savage Data utilities
- **Display name:** "Enova Power, Ontario (SANDBOX FOR TESTING ONLY)"

Registration completed by @kennek6 via https://enovaonboarding.savagedata.com/.
Client credentials were emailed separately.

Relates to #36, complements #61 (utility documentation).